### PR TITLE
Sletter løpende kontantstøtte endepunkt brukt i ks sak og ks mottak

### DIFF
--- a/src/main/kotlin/no/nav/infotrygd/kontantstotte/rest/controller/InnsynController.kt
+++ b/src/main/kotlin/no/nav/infotrygd/kontantstotte/rest/controller/InnsynController.kt
@@ -37,14 +37,6 @@ class InnsynController(
         return innsynService.hentDataForBarn(req)
     }
 
-    @PostMapping("/harLøpendeKontantstotteIInfotrygd", "/harLopendeKontantstotteIInfotrygd")
-    fun harKontantstotteIInfotrygd(
-        @RequestBody req: InnsynRequest,
-    ): Boolean {
-        tilgangskontrollService.sjekkTilgang()
-        return innsynService.harKontantstotte(req)
-    }
-
     @GetMapping("/hentidentertilbarnmedlopendesaker")
     fun harKontantstotteIInfotrygd(): List<String> {
         tilgangskontrollService.sjekkTilgang()

--- a/src/main/kotlin/no/nav/infotrygd/kontantstotte/service/InnsynService.kt
+++ b/src/main/kotlin/no/nav/infotrygd/kontantstotte/service/InnsynService.kt
@@ -12,7 +12,6 @@ import no.nav.infotrygd.kontantstotte.repository.StonadRepository
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import java.time.YearMonth
 
 @Service
 class InnsynService(
@@ -32,15 +31,6 @@ class InnsynService(
         return InnsynResponse(
             data = stonader.map { it.toDto() },
         )
-    }
-
-    fun harKontantstotte(req: InnsynRequest): Boolean {
-        val barna = barnRepository.findByFnrIn(req.barn.tilFoedselsnummere())
-        val stonader = stonadRepository.findByBarnIn(barna).filter { it.tom == null || it.tom!! > YearMonth.now() }
-
-        logger.info("Fant ${stonader.size} for barna")
-        secureLogger.info("Fant ${stonader.size} for barna $barna")
-        return stonader.isNotEmpty()
     }
 
     fun hentbarnmedløpendekontantstøtte(): List<String> {

--- a/src/test/kotlin/no/nav/infotrygd/kontantstotte/IntegrasjonTest.kt
+++ b/src/test/kotlin/no/nav/infotrygd/kontantstotte/IntegrasjonTest.kt
@@ -6,7 +6,6 @@ import no.nav.infotrygd.kontantstotte.testutil.StonadFactory
 import no.nav.infotrygd.kontantstotte.testutil.TestData
 import no.nav.infotrygd.kontantstotte.testutil.rest.TestClientException
 import no.nav.infotrygd.kontantstotte.testutil.rest.TestClientFactory
-import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -26,9 +25,6 @@ internal class IntegrasjonTest {
     private lateinit var testClientFactory: TestClientFactory
 
     @Autowired
-    private lateinit var mockOAuth2Server: MockOAuth2Server
-
-    @Autowired
     private lateinit var stonadRepository: StonadRepository
 
     @Test
@@ -44,36 +40,6 @@ internal class IntegrasjonTest {
         )
 
         assertThat(res.data).hasSameSizeAs(listOf(stonad))
-    }
-
-    @Test
-    fun harKontantstotteIInfotrygd() {
-        val sf = StonadFactory()
-        val stonad = sf.stonad(barnEksempler = listOf(sf.barn()))
-        stonadRepository.save(stonad)
-
-        val res = testClientFactory.get(port).harKontantstotteIInfotrygd(
-            InnsynRequest(
-                barn = listOf(stonad.barn.first().fnr.asString),
-            ),
-        )
-
-        assertThat(res).isEqualTo(true)
-    }
-
-    @Test
-    fun harIkkeKontantstotteIInfotrygd() {
-        val sf = StonadFactory()
-        val stonad = sf.stonad(barnEksempler = listOf(sf.barn()), opphoertVfom = "012021")
-        stonadRepository.save(stonad)
-
-        val res = testClientFactory.get(port).harKontantstotteIInfotrygd(
-            InnsynRequest(
-                barn = listOf(stonad.barn.first().fnr.asString),
-            ),
-        )
-
-        assertThat(res).isEqualTo(false)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/infotrygd/kontantstotte/testutil/rest/TestClient.kt
+++ b/src/test/kotlin/no/nav/infotrygd/kontantstotte/testutil/rest/TestClient.kt
@@ -15,10 +15,6 @@ class TestClient(private val restTemplate: RestTemplate) {
         return restTemplate.postForObject("/api/hentPerioderMedKontantstøtteIInfotrygd", req)
     }
 
-    fun harKontantstotteIInfotrygd(req: InnsynRequest): Boolean {
-        return restTemplate.postForObject("/api/harLøpendeKontantstotteIInfotrygd", req)
-    }
-
     fun hentAlleBarnMedLøpendeFagsak(): List<String> {
         return restTemplate.getForObject("/api/hentidentertilbarnmedlopendesaker")
     }


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-23091

Siden ∂et ikke eksisterer løpende KS i infotrygd lenger fjerner vi endepunkt som brukes av ks og baks mottak for dette.