### PR TITLE
Skru på logg-splitting til Elastic og Loki

### DIFF
--- a/.nais/app-dev.yaml
+++ b/.nais/app-dev.yaml
@@ -36,6 +36,11 @@ spec:
     requests: # App is guaranteed the requested resources and  will be scheduled on nodes with at least this amount of resources available
       cpu: 500m
       memory: 1024Mi
+  observability:
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   ingresses:
   - https://familie-ks-infotrygd.dev-fss-pub.nais.io
   - https://familie-ks-infotrygd.dev.intern.nav.no/

--- a/.nais/app-prod.yaml
+++ b/.nais/app-prod.yaml
@@ -36,6 +36,11 @@ spec:
     requests: # App is guaranteed the requested resources and  will be scheduled on nodes with at least this amount of resources available
       cpu: 100m
       memory: 1024Mi
+  observability:
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
   ingresses:
   - "https://familie-ks-infotrygd.prod-fss-pub.nais.io"
   - "https://familie-ks-infotrygd.intern.nav.no"


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Skrur på logg-splitting for app, som betyr at vi sender logs til både Elastic (Kibana) og (Grafana) Loki. Dette er en midlertidig løsning mens vi enda blir kjent med Loki og får satt opp ting slik vi ønsker det.

Favro: NAV-25157